### PR TITLE
Removing three Function of IWorkOrderPolicy  to another class .

### DIFF
--- a/src/MechanicApplication/Common/Interfaces/IWorkOrderPolicy.cs
+++ b/src/MechanicApplication/Common/Interfaces/IWorkOrderPolicy.cs
@@ -8,9 +8,5 @@ namespace MechanicApplication.Common.Interfaces;
 public interface IWorkOrderPolicy
 {
     bool IsOutsideOperatingHours(DateTimeOffset startAt, TimeSpan duration);
-    Task<bool> IsLaborOccupied(Guid laborId, Guid excludeWorkOrderOrderId, DateTimeOffset startAt, DateTimeOffset endAt);
-    Task<bool> IsVehicleAlreadyScheduled(Guid vehicleId, DateTimeOffset startAt, DateTimeOffset endAt);
-    Task<ErrorOr<Success>> IsSpotAvailableAsync(Spot spot, DateTimeOffset startAt
-        , DateTimeOffset endAt,Guid? excludeWorkOrderId = null, CancellationToken cancellation= default);
     ErrorOr<Success> IsGreaterThanMinimalAppointmentDuration(DateTimeOffset startAt, DateTimeOffset endAt);
 }

--- a/src/MechanicApplication/Features/WorkOrders/Services/AvailabilityChecker.cs
+++ b/src/MechanicApplication/Features/WorkOrders/Services/AvailabilityChecker.cs
@@ -1,0 +1,53 @@
+﻿
+using ErrorOr;
+using MechanicApplication.Common.Errors;
+using MechanicApplication.Common.Interfaces;
+using MechanicDomain.WorkOrders.Enums;
+using Microsoft.EntityFrameworkCore;
+
+namespace MechanicApplication.Features.WorkOrders.Services;
+
+public class AvailabilityChecker(IAppDbContext context)
+{
+    private readonly IAppDbContext _context = context;
+    public async Task<bool> IsLaborOccupied(Guid laborId, Guid excludeWorkOrderOrderId, DateTimeOffset startAt, DateTimeOffset endAt)
+    {
+        return await _context.WorkOrders
+            .AnyAsync(wo =>
+                wo.LaborId == laborId &&
+                wo.Id != excludeWorkOrderOrderId &&
+                startAt < wo.EndAtUtc &&
+                endAt > wo.StartAtUtc
+            );
+    }
+
+    public async Task<ErrorOr<Success>> CheckSpotAvailabilityAsync(Spot spot, DateTimeOffset startAt, DateTimeOffset endAt, Guid? excludeWorkOrderId = null, CancellationToken ct = default)
+    {
+        var isOccupied = await _context.WorkOrders
+            .AnyAsync(wo =>
+                wo.Spot == spot &&
+                (excludeWorkOrderId == null || wo.Id != excludeWorkOrderId) &&
+                startAt < wo.EndAtUtc &&
+                endAt > wo.StartAtUtc
+            , ct);
+
+        return isOccupied
+            ? Error.Conflict("MechanicShop_Spot_Full", "The selected time slot is unavailable for the requested services.")
+            : Result.Success;
+
+    }
+    public async Task<bool> IsVehicleAlreadyScheduled(
+        Guid vehicleId,
+        DateTimeOffset startAt,
+        DateTimeOffset endAt,
+        Guid? excludedWorkOrderId = null)
+    {
+        return await _context.WorkOrders
+            .AnyAsync(wo =>
+                wo.VehicleId == vehicleId &&
+                (excludedWorkOrderId == null || wo.Id != excludedWorkOrderId) &&
+                startAt < wo.EndAtUtc &&
+                endAt > wo.StartAtUtc
+            );
+    }
+}


### PR DESCRIPTION
Define this class in the Application layer. 
Those functions is application logic and does not require accessing any external services (By their own, otherwise they depend on the `IAppDbContext` of course). 

Thus it is more convenient to define them in the  Application. The only place using them. 